### PR TITLE
Port and mariadb

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,11 +12,11 @@ $ helm install stable/bookstack
 
 This chart bootstraps a [Bookstack](https://hub.docker.com/r/solidnerd/bookstack/) deployment on a [Kubernetes](http://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
 
-It also uses the [MariaDB chart](https://github.com/kubernetes/charts/tree/master/stable/mariadb) which satisfies the database requirements of the application.
+It also uses the [MariaDB chart](https://github.com/bitnami/charts/tree/master/bitnami/mariadb) which satisfies the database requirements of the application.
 
 ## Prerequisites
 
-- Kubernetes 1.9+ with Beta APIs enabled
+- Kubernetes 1.12+
 - PV provisioner support in the underlying infrastructure
 
 ## Installing the Chart
@@ -43,7 +43,7 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ## Configuration
 
-The following table lists the configurable parameters of the Redmine chart and their default values.
+The following table lists the configurable parameters of the chart and their default values.
 
 |            Parameter              |              Description                 |                          Default                        | 
 | --------------------------------- | ---------------------------------------- | ------------------------------------------------------- |
@@ -58,14 +58,14 @@ The following table lists the configurable parameters of the Redmine chart and t
 | `externalDatabase.password`       | Password for the above username          | `nil`                                                   |
 | `externalDatabase.database`       | Name of the existing database            | `bookstack`                                             |
 | `mariadb.enabled`                 | Whether to use the MariaDB chart         | `true`                                                  |
-| `mariadb.db.name`                 | Database name to create                  | `bookstack`                                             |
-| `mariadb.db.user`                 | Database user to create                  | `bookstack`                                             |
-| `mariadb.db.password`             | Password for the database                | `nil`                                                   |
-| `mariadb.rootUser.password`        | MariaDB admin password                   | `nil`                                                   |
-| `mariadb.master.persistence.enabled`        | Enable MariaDB persistence using PVC     | `false`                                                  |
-| `mariadb.master.persistence.storageClass`   | PVC Storage Class for MariaDB volume     | `nil` (uses alpha storage class annotation)             |
-| `mariadb.master.persistence.accessMode`     | PVC Access Mode for MariaDB volume       | `ReadWriteOnce`                                         |
-| `mariadb.master.persistence.size`           | PVC Storage Request for MariaDB volume   | `8Gi`                                                   |
+| `mariadb.auth.database`           | Database name to create                  | `bookstack`                                             |
+| `mariadb.auth.username`           | Database user to create                  | `bookstack`                                             |
+| `mariadb.auth.password`           | Password for the database                | `nil`                                                   |
+| `mariadb.auth.rootPassword`       | MariaDB admin password                   | `nil`                                                   |
+| `mariadb.primary.persistence.enabled`        | Enable MariaDB persistence using PVC     | `false`                                                  |
+| `mariadb.primary.persistence.storageClass`   | PVC Storage Class for MariaDB volume     | `nil` (uses alpha storage class annotation)             |
+| `mariadb.primary.persistence.accessMode`     | PVC Access Mode for MariaDB volume       | `ReadWriteOnce`                                         |
+| `mariadb.primary.persistence.size`           | PVC Storage Request for MariaDB volume   | `8Gi`                                                   |
 | `service.type`                    | Desired service type                                | `ClusterIP`               |
 | `service.port`                    | Service exposed port                               | `80`                    |
 | `podSecurityPolicy.enabled`	    | Create & use Pod Security Policy resources  | `false`						      |

--- a/requirements.lock
+++ b/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: mariadb
-  repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 4.4.0
-digest: sha256:539db9dd569487a45e5736c58738195bb655669b99dd18018828c0638f75cc7d
-generated: 2018-09-03T12:28:18.799732074Z
+  repository: https://charts.bitnami.com/bitnami
+  version: 9.0.1
+digest: sha256:0ff613600e2f82ff620a41f6a82649df1d01caa239434af0581d21cb7fd3e995
+generated: "2020-11-21T13:14:15.714142277+01:00"

--- a/requirements.yaml
+++ b/requirements.yaml
@@ -1,5 +1,5 @@
 dependencies:
 - name: mariadb
-  version: 4.4.x
-  repository: https://kubernetes-charts.storage.googleapis.com/
+  version: 9.0.x
+  repository: https://charts.bitnami.com/bitnami
   condition: mariadb.enabled

--- a/templates/NOTES.txt
+++ b/templates/NOTES.txt
@@ -15,5 +15,5 @@
 {{- else if contains "ClusterIP" .Values.service.type }}
   export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "bookstack.name" . }},release={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
   echo "Visit http://127.0.0.1:8080 to use your application"
-  kubectl port-forward $POD_NAME 8080:80
+  kubectl port-forward $POD_NAME 8080:{{ .Values.app.port }}
 {{- end }}

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -57,9 +57,9 @@ spec:
             - name: DB_HOST
               value: {{ template "bookstack.mariadb.fullname" . }}
             - name: DB_DATABASE
-              value: {{ .Values.mariadb.db.name | quote }}
+              value: {{ .Values.mariadb.auth.database | quote }}
             - name: DB_USERNAME
-              value: {{ .Values.mariadb.db.user | quote }}
+              value: {{ .Values.mariadb.auth.username | quote }}
             - name: DB_PASSWORD
               valueFrom:
                 secretKeyRef:

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -26,7 +26,7 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
             - name: http
-              containerPort: 80
+              containerPort: {{ .Values.app.port }}
               protocol: TCP
           livenessProbe:
             httpGet:

--- a/templates/service.yaml
+++ b/templates/service.yaml
@@ -11,7 +11,7 @@ spec:
   type: {{ .Values.service.type }}
   ports:
     - port: {{ .Values.service.port }}
-      targetPort: http
+      targetPort: {{ .Values.app.port }}
       protocol: TCP
       name: http
   selector:

--- a/values.yaml
+++ b/values.yaml
@@ -12,6 +12,9 @@ image:
 app:
   # Laravel APP_KEY. Generate one with `php artisan key:generate` and put here if you want a static key.
   key:
+  # Port the bookstack app is running under.
+  # For the solidnerd/bookstack image, this will be port 80 for versions < 0.28.0, 8080 for later versions
+  port: 8080
 
 env: {}
 

--- a/values.yaml
+++ b/values.yaml
@@ -44,30 +44,28 @@ mariadb:
   ## Whether to deploy a mariadb server to satisfy the applications database requirements. To use an external database set this to false and configure the externalDatabase parameters
   enabled: true
 
-  ## Disable MariaDB replication
-  replication:
-    enabled: false
+  ## Set MariaDB architecture: standalone or replication
+  architecture: standalone
 
   ## Create a database and a database user
   ## ref: https://github.com/bitnami/bitnami-docker-mariadb/blob/master/README.md#creating-a-database-user-on-first-run
   ##
-  db:
-    name: bookstack
-    user: bookstack
+  auth:
+    database: bookstack
+    username: bookstack
     ## If the password is not specified, mariadb will generates a random password
     ##
     # password:
 
-  ## MariaDB admin password
-  ## ref: https://github.com/bitnami/bitnami-docker-mariadb/blob/master/README.md#setting-the-root-password-on-first-run
-  ##
-  # rootUser:
-  #   password:
+    ## MariaDB admin password
+    ## ref: https://github.com/bitnami/bitnami-docker-mariadb/blob/master/README.md#setting-the-root-password-on-first-run
+    ##
+    # rootPassword:
 
   ## Enable persistence using Persistent Volume Claims
   ## ref: http://kubernetes.io/docs/user-guide/persistent-volumes/
   ##
-  master:
+  primary:
     persistence:
       enabled: false
       ## mariadb data Persistent Volume Storage Class


### PR DESCRIPTION
Allows configuring the pod port, so we can support newer versions of the bookstack image.

Updates the mariadb chart and changes documentation and values.yaml accordingly.